### PR TITLE
Implement modifiable Lock-On FOV

### DIFF
--- a/FFXVIFix.ini
+++ b/FFXVIFix.ini
@@ -28,6 +28,9 @@ Enabled = true
 ; Add to gameplay vFOV in degrees. Default = 0 (Valid range: -40 to 140)
 ; I recommend a figure between 5 to 15 for a wider view.
 AdditionalFOV = 0
+; Add to gameplay (during lock-on) vFOV in degrees. Default = 0 (Valid range: -40 to 140)
+; I recommend a figure between 5 to 15 for a wider view.
+AdditionalFOVLockOn = 0
 ; Adjust character camera position horizontally. 
 ; Above 0 has the character on the left, below 0 on the right. Centered = 0 , Default = 0.95 (Valid range: -5 to 5)
 HorizontalPos = 0.95

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -776,7 +776,8 @@ void Camera()
             static SafetyHookMid GameplayFOVMidHook{};
             GameplayFOVMidHook = safetyhook::create_mid(GameplayFOVScanResult + 0x10,
                 [](SafetyHookContext& ctx) {
-                    ctx.xmm0.f32[0] += fGameplayCamFOV;
+					float fov = std::clamp(ctx.xmm0.f32[0] + fGameplayCamFOV, 1.0f, 179.0f);
+                    ctx.xmm0.f32[0] = fov;
                 });
         }
         else if (!GameplayFOVScanResult) {
@@ -792,7 +793,9 @@ void Camera()
 			static SafetyHookMid LockOnFOVMidHook{};
 			LockOnFOVMidHook = safetyhook::create_mid(LockOnFOVScanResult + 8,
 				[](SafetyHookContext& ctx) {
-					ctx.xmm0.f32[0] += (fLockonCamFOV * (fPi / 180.0f));
+					const float DTOR = fPi / 180.0f;
+					float fov = std::clamp(ctx.xmm0.f32[0] + (fLockonCamFOV * DTOR), 1 * DTOR, 179 * DTOR);
+					ctx.xmm0.f32[0] = fov;
 				});
 		}
 		else if (!LockOnFOVScanResult) {

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -743,103 +743,104 @@ void HUD()
     }
 }
 
+static SafetyHookInline sLockOnFOVInlineHook{};
+
+float LockOnFOVHook(void) {
+	const float DTOR = fPi / 180.0f;
+	float result = sLockOnFOVInlineHook.call<float>();
+	return std::clamp(result + (fLockonCamFOV * DTOR), 1.0f * DTOR, 179.0f * DTOR);
+}
+
 void Camera()
 {
-    if (bFixFOV) { 
-        // Fix <16:9 FOV
-        uint8_t* FOVScanResult = Memory::PatternScan(baseModule, "89 ?? ?? ?? ?? ?? 48 8B ?? ?? 48 8B ?? ?? C5 ?? ?? ?? ?? ?? ?? ?? 48 8B ?? 48 8B ?? FF 90 ?? ?? ?? ??");
-        if (FOVScanResult) {
-            spdlog::info("FOV: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)FOVScanResult - (uintptr_t)baseModule);
+	if (bFixFOV) {
+		// Fix <16:9 FOV
+		uint8_t* FOVScanResult = Memory::PatternScan(baseModule, "89 ?? ?? ?? ?? ?? 48 8B ?? ?? 48 8B ?? ?? C5 ?? ?? ?? ?? ?? ?? ?? 48 8B ?? 48 8B ?? FF 90 ?? ?? ?? ??");
+		if (FOVScanResult) {
+			spdlog::info("FOV: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)FOVScanResult - (uintptr_t)baseModule);
 
-            static SafetyHookMid FOVMidHook{};
-            FOVMidHook = safetyhook::create_mid(FOVScanResult,
-                [](SafetyHookContext& ctx) {
-                    // Fix cropped FOV when at <16:9
-                    if (fAspectRatio < fNativeAspect) {
-                        float fov = *reinterpret_cast<float*>(&ctx.rax);
-                        fov = 2.0f * atanf(tanf(fov / 2.0f) * (fNativeAspect / fAspectRatio));
-                        ctx.rax = *(uint32_t*)&fov;
-                    }     
-                });
-        }
-        else if (!FOVScanResult) {
-            spdlog::error("FOV: Pattern scan failed.");
-        }
-    }
+			static SafetyHookMid FOVMidHook{};
+			FOVMidHook = safetyhook::create_mid(FOVScanResult,
+				[](SafetyHookContext& ctx) {
+					// Fix cropped FOV when at <16:9
+					if (fAspectRatio < fNativeAspect) {
+						float fov = *reinterpret_cast<float*>(&ctx.rax);
+						fov = 2.0f * atanf(tanf(fov / 2.0f) * (fNativeAspect / fAspectRatio));
+						ctx.rax = *(uint32_t*)&fov;
+					}
+				});
+		}
+		else if (!FOVScanResult) {
+			spdlog::error("FOV: Pattern scan failed.");
+		}
+	}
 
-    if (fGameplayCamFOV != 0.00f) {
-        // Gameplay FOV
-        uint8_t* GameplayFOVScanResult = Memory::PatternScan(baseModule, "48 8D ?? ?? ?? ?? ?? C3 C5 FA ?? ?? ?? ?? ?? 00 C5 FA ?? ?? ?? ?? ?? ?? C5 F2 ?? ?? ?? ?? ?? ?? C3");
-        if (GameplayFOVScanResult) {
-            spdlog::info("Gameplay Camera: FOV: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)GameplayFOVScanResult - (uintptr_t)baseModule);
+	if (fGameplayCamFOV != 0.00f) {
+		// Gameplay FOV
+		uint8_t* GameplayFOVScanResult = Memory::PatternScan(baseModule, "48 8D ?? ?? ?? ?? ?? C3 C5 FA ?? ?? ?? ?? ?? 00 C5 FA ?? ?? ?? ?? ?? ?? C5 F2 ?? ?? ?? ?? ?? ?? C3");
+		if (GameplayFOVScanResult) {
+			spdlog::info("Gameplay Camera: FOV: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)GameplayFOVScanResult - (uintptr_t)baseModule);
 
-            static SafetyHookMid GameplayFOVMidHook{};
-            GameplayFOVMidHook = safetyhook::create_mid(GameplayFOVScanResult + 0x10,
-                [](SafetyHookContext& ctx) {
+			static SafetyHookMid GameplayFOVMidHook{};
+			GameplayFOVMidHook = safetyhook::create_mid(GameplayFOVScanResult + 0x10,
+				[](SafetyHookContext& ctx) {
 					float fov = std::clamp(ctx.xmm0.f32[0] + fGameplayCamFOV, 1.0f, 179.0f);
-                    ctx.xmm0.f32[0] = fov;
-                });
-        }
-        else if (!GameplayFOVScanResult) {
-            spdlog::error("Gameplay Camera: FOV: Pattern scan failed.");
-        }
-    }
+					ctx.xmm0.f32[0] = fov;
+				});
+		}
+		else if (!GameplayFOVScanResult) {
+			spdlog::error("Gameplay Camera: FOV: Pattern scan failed.");
+		}
+	}
 
 	if (fLockonCamFOV != 0.00f) {
 		uint8_t* LockOnFOVScanResult = Memory::PatternScan(baseModule, "c5 fa ?? ?? ?? ?? ?? ?? c3 cc cc cc 48 8b 42 ?? 48 89 41"); // a function that returns 0.6981317f from rodata, called from a function pointer at the sig 'ff 90 ?? ?? 00 00 c5 fa 11 47 ?? 48 8b 03 48 8b cb'
 		if (LockOnFOVScanResult) {
 			spdlog::info("Gameplay Camera: LockOn FOV: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)LockOnFOVScanResult - (uintptr_t)baseModule);
-
-			static SafetyHookMid LockOnFOVMidHook{};
-			LockOnFOVMidHook = safetyhook::create_mid(LockOnFOVScanResult + 8,
-				[](SafetyHookContext& ctx) {
-					const float DTOR = fPi / 180.0f;
-					float fov = std::clamp(ctx.xmm0.f32[0] + (fLockonCamFOV * DTOR), 1 * DTOR, 179 * DTOR);
-					ctx.xmm0.f32[0] = fov;
-				});
+			sLockOnFOVInlineHook = safetyhook::create_inline(reinterpret_cast<void*>(LockOnFOVScanResult), LockOnFOVHook);
 		}
 		else if (!LockOnFOVScanResult) {
 			spdlog::error("Gameplay Camera: LockOn FOV: Pattern scan failed.");
 		}
 	}
 
-    if (fGameplayCamHorPos != 0.95f || fGameplayCamVertPos != -0.65f) {
-        // Gameplay Camera Position
-        uint8_t* GameplayCameraPosScanResult = Memory::PatternScan(baseModule, "C5 ?? ?? ?? ?? ?? ?? ?? 8B ?? 41 ?? ?? 48 8D ?? ?? E8 ?? ?? ?? ??");
-        if (GameplayCameraPosScanResult) {
-            spdlog::info("Gameplay Camera: Position: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)GameplayCameraPosScanResult - (uintptr_t)baseModule);
+	if (fGameplayCamHorPos != 0.95f || fGameplayCamVertPos != -0.65f) {
+		// Gameplay Camera Position
+		uint8_t* GameplayCameraPosScanResult = Memory::PatternScan(baseModule, "C5 ?? ?? ?? ?? ?? ?? ?? 8B ?? 41 ?? ?? 48 8D ?? ?? E8 ?? ?? ?? ??");
+		if (GameplayCameraPosScanResult) {
+			spdlog::info("Gameplay Camera: Position: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)GameplayCameraPosScanResult - (uintptr_t)baseModule);
 
-            static SafetyHookMid GameplayCameraHorPosMidHook{};
-            GameplayCameraHorPosMidHook = safetyhook::create_mid(GameplayCameraPosScanResult + 0x8,
-                [](SafetyHookContext& ctx) {
-                    if (fGameplayCamHorPos != 0.95f) 
-                    ctx.xmm1.f32[0] = fGameplayCamHorPos;
+			static SafetyHookMid GameplayCameraHorPosMidHook{};
+			GameplayCameraHorPosMidHook = safetyhook::create_mid(GameplayCameraPosScanResult + 0x8,
+				[](SafetyHookContext& ctx) {
+					if (fGameplayCamHorPos != 0.95f)
+						ctx.xmm1.f32[0] = fGameplayCamHorPos;
 
-                    if (fGameplayCamVertPos != -0.65f)
-                    ctx.xmm2.f32[0] = fGameplayCamVertPos;
-                });
-        }
-        else if (!GameplayCameraPosScanResult) {
-            spdlog::error("Gameplay Camera: Position: Pattern scan failed.");
-        }
-    }
+					if (fGameplayCamVertPos != -0.65f)
+						ctx.xmm2.f32[0] = fGameplayCamVertPos;
+				});
+		}
+		else if (!GameplayCameraPosScanResult) {
+			spdlog::error("Gameplay Camera: Position: Pattern scan failed.");
+		}
+	}
 
-    if (fGameplayCamDistMulti != 1.00f) {
-        // Gameplay Camera Distance
-        uint8_t* GameplayCameraDistScanResult = Memory::PatternScan(baseModule, "C5 ?? ?? ?? ?? ?? ?? ?? 48 8D ?? ?? ?? ?? ?? 4C 8D ?? ?? ?? ?? ?? 48 8B ?? C4 ?? ?? ?? ?? E8 ?? ?? ?? ??");
-        if (GameplayCameraDistScanResult) {
-            spdlog::info("Gameplay Camera: Distance: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)GameplayCameraDistScanResult - (uintptr_t)baseModule);
+	if (fGameplayCamDistMulti != 1.00f) {
+		// Gameplay Camera Distance
+		uint8_t* GameplayCameraDistScanResult = Memory::PatternScan(baseModule, "C5 ?? ?? ?? ?? ?? ?? ?? 48 8D ?? ?? ?? ?? ?? 4C 8D ?? ?? ?? ?? ?? 48 8B ?? C4 ?? ?? ?? ?? E8 ?? ?? ?? ??");
+		if (GameplayCameraDistScanResult) {
+			spdlog::info("Gameplay Camera: Distance: Address is {:s}+{:x}", sExeName.c_str(), (uintptr_t)GameplayCameraDistScanResult - (uintptr_t)baseModule);
 
-            static SafetyHookMid GameplayCameraDistMidHook{};
-            GameplayCameraDistMidHook = safetyhook::create_mid(GameplayCameraDistScanResult,
-                [](SafetyHookContext& ctx) {
-                    ctx.xmm3.f32[0] *= fGameplayCamDistMulti;
-                });
-        }
-        else if (!GameplayCameraDistScanResult) {
-            spdlog::error("Gameplay Camera: Distance: Pattern scan failed.");
-        }
-    }  
+			static SafetyHookMid GameplayCameraDistMidHook{};
+			GameplayCameraDistMidHook = safetyhook::create_mid(GameplayCameraDistScanResult,
+				[](SafetyHookContext& ctx) {
+					ctx.xmm3.f32[0] *= fGameplayCamDistMulti;
+				});
+		}
+		else if (!GameplayCameraDistScanResult) {
+			spdlog::error("Gameplay Camera: Distance: Pattern scan failed.");
+		}
+	}
 }
 
 void Framerate()


### PR DESCRIPTION
Relevant to issue #56 
Found the relevant function by going up the call stack and peeking at the function that was alternatively being called when locked on. Annoyingly, the function just returns a float from rodata so it's sig might be pretty weak, since it relies on the following function.
In any case, this allows the user to adjust the lock-on fov separately from the normal gameplay fov.

Note that the camera also shifts position (I am assuming the distance multiplier reduces slightly here), and this does not resolve that issue.